### PR TITLE
Generate a new file if NGINX template exists

### DIFF
--- a/auto_ssl.sh
+++ b/auto_ssl.sh
@@ -140,8 +140,7 @@ function create_nginx_vhost(){
     if [[ ${BASE_DOMAIN} != "no" ]]; then
         SERVER_NAME="${INPUT_DOMAIN} ${BASE_DOMAIN}"
     fi
-
-cat << EOF | sudo tee /etc/nginx/conf.d/$INPUT_DOMAIN.conf
+NGINX_CONFIG_TEMPLATE=$(cat << EOF
 server {
     listen       80;
     server_name ${SERVER_NAME};
@@ -193,7 +192,17 @@ server {
 #     error_log ${NGINX_WEB_ROOT}/${INPUT_DOMAIN}/logs/error.log;
 # }
 EOF
+)
 
+  TARGET_FILE="/etc/nginx/conf.d/$INPUT_DOMAIN.conf"
+  AUTO_SSL_FILE="/etc/nginx/conf.d/$INPUT_DOMAIN.conf.autossl"
+  if [[ -f $TARGET_FILE ]]; then
+      echo "File $TARGET_FILE exists. Writing to $AUTO_SSL_FILE."
+      echo "$NGINX_CONFIG_TEMPLATE" | sudo tee $AUTO_SSL_FILE
+  else
+      echo "File $TARGET_FILE does not exist. Writing to $TARGET_FILE."
+      echo "$NGINX_CONFIG_TEMPLATE" | sudo tee $TARGET_FILE
+  fi
 
     mkdir -p $NGINX_WEB_ROOT/${INPUT_DOMAIN}/cert
     mkdir -p $NGINX_WEB_ROOT/${INPUT_DOMAIN}/web_root


### PR DESCRIPTION
如果要生成的目标配置文件存在，则不覆盖原文件，生成一个原文件名+.autossl的文件。例如脚本要生成一个foo.example.com.conf时，如果此文件存在则新生成为foo.example.com.conf.autossl文件，不存在则生成foo.example.com.conf文件